### PR TITLE
auto generate test queries to new erddap datasets

### DIFF
--- a/.github/workflows/add-erddap-datasets-checks.yml
+++ b/.github/workflows/add-erddap-datasets-checks.yml
@@ -23,7 +23,7 @@ jobs:
           pip install pandas
 
       - name: Run ERDDAP checks update
-        run: python generate-sites-yaml-block.yaml '${secrets.ERDDAP_SERVERS}'
+        run: python generate-sites-yaml-block.py '${secrets.ERDDAP_SERVERS}'
 
       - name: push changes
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/add-erddap-datasets-checks.yml
+++ b/.github/workflows/add-erddap-datasets-checks.yml
@@ -1,0 +1,33 @@
+name: Add New ERDDAP Datasets Checks
+on:
+  schedule:
+    - cron: '* */12 * * *'
+jobs:
+  release:
+    name: Add New ERDDAP Datasets Checks
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GH_PAT || github.token }}
+      - name: setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' # install the python version needed
+
+      - name: install python packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install pandas
+
+      - name: Run ERDDAP checks update
+        run: python generate-sites-yaml-block.yaml '${secrets.ERDDAP_SERVERS}'
+
+      - name: push changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Add ERDDAP Checks
+          branch: master
+          file_pattern: .upptimerc.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode/**
+__pycache__/generate-erddap-datasets-checks.cpython-39.pyc
+*.pyc
+.DS_Store

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -1,169 +1,330 @@
-owner: hakai-it # GitHub username
+owner: hakai-it
 repo: hakai-datasets-upptime
-sites: # List of endpoints to track
-  - name: HakaiADCPTimeSeriesProfileProvisional
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiADCPTimeSeriesProfileProvisional.htmlTable?time&time<=now-1week&distinct()
-  - name: HakaiSewardBoL5min
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiSewardBoL5min.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiQuadraBoLResearch
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraBoLResearch.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiBaynesSoundBoL5min
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiBaynesSoundBoL5min.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiKetchikanBoLResearch
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiKetchikanBoLResearch.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiSitkaBoL5min
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiSitkaBoL5min.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiADCPTimeSeriesProfileProvisional
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiADCPTimeSeriesProfileProvisional.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiWaterPropertiesInstrumentProfileProvisional
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiWaterPropertiesInstrumentProfileProvisional.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiMooredTimeSeriesResearch
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiMooredTimeSeriesResearch.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiCalvertCP1TideGauge
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiCalvertCP1TideGauge.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiQuadraBoL5min
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraBoL5min.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiKodiakBoL5min
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiKodiakBoL5min.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiKetchikanBoL5min
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiKetchikanBoL5min.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiKCBuoyResearch
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiKCBuoyResearch.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiPruthDockProvisional
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiPruthDockProvisional.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiQuadraWeather5min
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraWeather5min.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiQU5MMooringProvisional
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiQU5MMooringProvisional.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiWaterPropertiesInstrumentProfileResearch
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiWaterPropertiesInstrumentProfileResearch.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiKCBuoy1hour
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiKCBuoy1hour.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiSitkaBoLResearch
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiSitkaBoLResearch.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiQuadraLimpet5min
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraLimpet5min.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiColumbiaFerryResearch
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiColumbiaFerryResearch.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-  - name: HakaiPruthMooringProvisional
-    url: https://catalogue.hakai.org/erddap/tabledap/HakaiPruthMooringProvisional.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404
-
+sites:
+- name: HakaiADCPTimeSeriesProfileProvisional
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiADCPTimeSeriesProfileProvisional.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiSewardBoL5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiSewardBoL5min.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiQuadraBoLResearch
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraBoLResearch.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiBaynesSoundBoL5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiBaynesSoundBoL5min.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiKetchikanBoLResearch
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiKetchikanBoLResearch.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiSitkaBoL5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiSitkaBoL5min.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiADCPTimeSeriesProfileProvisional
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiADCPTimeSeriesProfileProvisional.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiWaterPropertiesInstrumentProfileProvisional
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiWaterPropertiesInstrumentProfileProvisional.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiMooredTimeSeriesResearch
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiMooredTimeSeriesResearch.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiCalvertCP1TideGauge
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiCalvertCP1TideGauge.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiQuadraBoL5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraBoL5min.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiKodiakBoL5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiKodiakBoL5min.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiKetchikanBoL5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiKetchikanBoL5min.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiKCBuoyResearch
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiKCBuoyResearch.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiPruthDockProvisional
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiPruthDockProvisional.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiQuadraWeather5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraWeather5min.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiQU5MMooringProvisional
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiQU5MMooringProvisional.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiWaterPropertiesInstrumentProfileResearch
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiWaterPropertiesInstrumentProfileResearch.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiKCBuoy1hour
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiKCBuoy1hour.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiSitkaBoLResearch
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiSitkaBoLResearch.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiQuadraLimpet5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraLimpet5min.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiColumbiaFerryResearch
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiColumbiaFerryResearch.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: HakaiPruthMooringProvisional
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiPruthMooringProvisional.htmlTable?time&time<=now-1week&distinct()
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiADCPTimeSeriesProfileProvisional
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiADCPTimeSeriesProfileProvisional.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiMooredTimeSeriesResearch
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiMooredTimeSeriesResearch.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiWaterPropertiesInstrumentProfileProvisional
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiWaterPropertiesInstrumentProfileProvisional.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiWaterPropertiesInstrumentProfileResearch
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiWaterPropertiesInstrumentProfileResearch.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraBoLResearch
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraBoLResearch.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiSitkaBoLResearch
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiSitkaBoLResearch.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiKetchikanBoLResearch
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiKetchikanBoLResearch.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraWeather5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraWeather5min.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraLimpet5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraLimpet5min.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  name: 'Real-Time: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraLimpet5min'
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraLimpet5min.htmlTable?time&time>=now-1day
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiPruthMooringProvisional
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiPruthMooringProvisional.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiPruthDockProvisional
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiPruthDockProvisional.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiQU5MMooringProvisional
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiQU5MMooringProvisional.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiBaynesSoundBoL5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiBaynesSoundBoL5min.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  name: 'Real-Time: https://catalogue.hakai.org/erddap/tabledap/HakaiBaynesSoundBoL5min'
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiBaynesSoundBoL5min.htmlTable?time&time>=now-1day
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraBoL5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraBoL5min.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  name: 'Real-Time: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraBoL5min'
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiQuadraBoL5min.htmlTable?time&time>=now-1day
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiKodiakBoL5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiKodiakBoL5min.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  name: 'Real-Time: https://catalogue.hakai.org/erddap/tabledap/HakaiKodiakBoL5min'
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiKodiakBoL5min.htmlTable?time&time>=now-1day
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiSewardBoL5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiSewardBoL5min.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  name: 'Real-Time: https://catalogue.hakai.org/erddap/tabledap/HakaiSewardBoL5min'
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiSewardBoL5min.htmlTable?time&time>=now-1day
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiKetchikanBoL5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiKetchikanBoL5min.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  name: 'Real-Time: https://catalogue.hakai.org/erddap/tabledap/HakaiKetchikanBoL5min'
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiKetchikanBoL5min.htmlTable?time&time>=now-1day
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiSitkaBoL5min
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiSitkaBoL5min.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  name: 'Real-Time: https://catalogue.hakai.org/erddap/tabledap/HakaiSitkaBoL5min'
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiSitkaBoL5min.htmlTable?time&time>=now-1day
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiKCBuoy1hour
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiKCBuoy1hour.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  name: 'Real-Time: https://catalogue.hakai.org/erddap/tabledap/HakaiKCBuoy1hour'
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiKCBuoy1hour.htmlTable?time&time>=now-1day
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiKCBuoyResearch
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiKCBuoyResearch.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiColumbiaFerryResearch
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiColumbiaFerryResearch.htmlTable?&time>now-1minute
+- expectedStatusCodes:
+  - 200
+  - 201
+  - 404
+  name: https://catalogue.hakai.org/erddap/tabledap/HakaiCalvertCP1TideGauge
+  url: https://catalogue.hakai.org/erddap/tabledap/HakaiCalvertCP1TideGauge.htmlTable?&time>now-1minute
 status-website:
-  # Add your custom domain name, or remove the `cname` line if you don't have a domain
-  # Uncomment the `baseUrl` line if you don't have a custom domain and add your repo name there
-  # cname: demo.upptime.js.org
   baseUrl: /hakai-datasets-uptime
+  introMessage: "This is a sample status page which uses **real-time** data from our\
+    \ [GitHub repository](https://github.com/hakaiInstitute/hakai-datasets-upptime).\
+    \ No server required \u2014 just GitHub Actions, Issues, and Pages. [**Get your\
+    \ own for free**](https://github.com/upptime/upptime)"
+  introTitle: '**Upptime** is the open-source uptime monitor and status page, powered
+    entirely by GitHub.'
   logoUrl: https://hakai.org/wp-content/themes/HakaiInstitute/images/logo.svg
-  name: Hakai ERDDAP Upptime
-  introTitle: "**Upptime** is the open-source uptime monitor and status page, powered entirely by GitHub."
-  introMessage: This is a sample status page which uses **real-time** data from our [GitHub repository](https://github.com/hakaiInstitute/hakai-datasets-upptime). No server required — just GitHub Actions, Issues, and Pages. [**Get your own for free**](https://github.com/upptime/upptime)
-  navbar:
-    - title: Status
-      href: /
-    - title: GitHub
-      href: https://github.com/$OWNER/$REPO
-  theme: ocean
   metaTags:
-    - name: "color-scheme"
-      content: "dark light"
-    - name: "robots"
-      content: "noindex"
-
-# Upptime also supports notifications, assigning issues, and more
-
+  - content: dark light
+    name: color-scheme
+  - content: noindex
+    name: robots
+  name: Hakai ERDDAP Upptime
+  navbar:
+  - href: /
+    title: Status
+  - href: https://github.com/$OWNER/$REPO
+    title: GitHub
+  theme: ocean
 workflowSchedule:
-  graphs: "0 0 * * *"
-  responseTime: "0 23 * * *"
-  staticSite: "0 1 * * *"
-  summary: "0 0 * * *"
-  updateTemplate: "0 0 * * *"
-  updates: "0 3 * * *"
-  uptime: "* */12 * * *"
+  graphs: 0 0 * * *
+  responseTime: 0 23 * * *
+  staticSite: 0 1 * * *
+  summary: 0 0 * * *
+  updateTemplate: 0 0 * * *
+  updates: 0 3 * * *
+  uptime: '* */12 * * *'

--- a/generate-sites-yaml-block.py
+++ b/generate-sites-yaml-block.py
@@ -1,16 +1,99 @@
 import pandas as pd
+import argparse
+import yaml
+from pathlib import Path
+import re
 
-#
-# Generates the sites block in .upptimerc.yml :
-# https://github.com/HakaiInstitute/hakai-datasets-upptime/blob/master/.upptimerc.yml
-#
-url='https://catalogue.hakai.org/erddap/tabledap/allDatasets.csv?datasetID&datasetID!="allDatasets"&accessible="public"'
+expected_status_code = [200, 201, 404]
 
-sites=pd.read_csv(url)['datasetID']
+# Load active config
+def load_upptimerc(path):
+    with open(path) as file_handle:
+        return yaml.load(file_handle, Loader=yaml.SafeLoader)
 
-for dataset_id in sites:
-    print (f"""  - name: {dataset_id}\n    url: https://catalogue.hakai.org/erddap/tabledap/{dataset_id}.htmlTable?time&time<=now-1week&distinct()
-    expectedStatusCodes:
-      - 200
-      - 201
-      - 404""")
+
+def save_upptimerc(config, path):
+    with open(path, "w") as file_handle:
+        yaml.dump(config, file_handle, default_flow_style=False)
+
+
+def get_erddap_datasets_upptime_checks(erddap_server, realtime_buffer="1day"):
+    """
+    Generates the sites block in .upptimerc.yml :
+    https://github.com/HakaiInstitute/hakai-datasets-upptime/blob/master/.upptimerc.yml
+    """
+
+    def _get_realtime_dataset_test_query(dataset_url):
+        return f"{dataset_url}.htmlTable?time&time<=now-1week&distinct()"
+
+    # Retrieve list of datasets
+    url = f'{erddap_server}/tabledap/allDatasets.csv?&datasetID!="allDatasets"&accessible="public"'
+    sites = pd.read_csv(url, skiprows=[1])
+    site_checks = []
+    for _, row in sites.dropna(subset=["tabledap"]).iterrows():
+        # regular check that looks at all variables
+        site_checks += [
+            dict(
+                name=row["tabledap"],
+                url=f'{row["tabledap"]}.htmlTable?&time>now-1minute',
+                expectedStatusCodes=[200, 201, 404],
+            )
+        ]
+
+        # realtime check if data exist within given time buffer
+        if re.search(r"real[-\s]*time", row["title"], re.IGNORECASE):
+            site_checks += [
+                dict(
+                    name=f"Real-Time: {row['tabledap']}",
+                    url=f"{row['tabledap']}.htmlTable?time&time>=now-{realtime_buffer}",
+                    expectedStatusCodes=[200],
+                )
+            ]
+            
+    return site_checks
+
+
+def update_upptimerc(config_path, erddap_server="", realtime_buffer="1day"):
+
+    config = load_upptimerc(config_path)
+
+    site_check_names = [site["name"] for site in config["sites"]]
+
+    # Retrieve list of erddap tests
+    new_site_checks = [
+        site
+        for server in erddap_server.split(",")
+        for site in get_erddap_datasets_upptime_checks(
+            server, realtime_buffer=realtime_buffer
+        )
+        if site["name"] not in site_check_names
+    ]
+
+    if not new_site_checks:
+        return
+
+    print(f"{len(new_site_checks)} new test sites added")
+    config["sites"] += new_site_checks
+    save_upptimerc(config, config_path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="generate-erddap-datasets-checks",
+        description="Generate upptime yaml entries specific to an erddap server datset",
+    )
+    parser.add_argument(
+        "erddap_servers", help="comma separated list of erddap servers url"
+    )
+    parser.add_argument(
+        "--upptimerc_file",
+        help="upptimeerc.yml file to load and update",
+        default=".upptimerc.yml",
+    )
+    parser.add_argument(
+        "--realtime_buffer",
+        help="Acceptable buffer time to test realtime datasets",
+        default="1day",
+    )
+    args = parser.parse_args()
+    update_upptimerc(args.upptimerc_file, args.erddap_servers, args.realtime_buffer)


### PR DESCRIPTION
Adds a workflow cron job to review a list of erddap datasets and generates test queries for each tabledap dataset available within a list of given erddap servers.

The list of erddap servers is given by the repo secret env variable ERDDAP_SERVERS.

The workflow run a regular basis and query each erddap servers for the list of datasets available. 
For each tabledap datasets, it will generate a default query that attempts to retrieve one minute of data with all the variables. It will accepts the status codes: 200,201 and 404. 

For any datasets that has realtime within their title, it will generate an extra query that tries to retrieve the data from `now - {time_buffer} ` until now. The `time_buffer` is default to `1day` but can be redefined.

Once those querries are generated, only the ones not already available within the `.upptimerc.yml` will be added and automatically commited to the repo master branch.

Site checks can then be manually fine tuned by changing the `upptimerc.yml`. Datasets that no longuer exists within the erddap will need to be manually taken down from the upptime configuration. 

